### PR TITLE
Use TradingEconomics API key for CN10Y watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ Utility scripts for monitoring financial indicators and sending Telegram alerts.
 ## Scripts
 
 - `monitor_brent.py` – Brent crude oil price watcher.
-- `monitor_cn10y.py` – China 10-year government bond yield watcher.
+- `monitor_cn10y.py` – China 10-year government bond yield watcher. Uses the
+  TradingEconomics API and reads the key from the `TE_API_KEY` environment
+  variable (falls back to public `guest:guest` credentials).


### PR DESCRIPTION
## Summary
- add support for `TE_API_KEY` and switch CN10Y watcher to TradingEconomics API
- document `TE_API_KEY` usage in README

## Testing
- `python monitor_cn10y.py` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ec38e2a8c832682f08eacfc4b10b6