### PR TITLE
feat: switch CN10Y yield source to Tushare

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Utility scripts for monitoring financial indicators and sending Telegram alerts.
 
 - `monitor_brent.py` – Brent crude oil price watcher.
 - `monitor_cn10y.py` – China 10-year government bond yield watcher. Uses the
-  TradingEconomics API and reads the key from the `TE_API_KEY` environment
-  variable (falls back to public `guest:guest` credentials).
+  Tushare Pro API and reads the token from the `TUSHARE_TOKEN` environment
+  variable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 yfinance>=0.2.43
 pandas>=2.2
 requests>=2.31
+tushare>=1.2.89


### PR DESCRIPTION
## Summary
- replace TradingEconomics/EastMoney logic with Tushare API
- document TUSHARE_TOKEN environment variable
- add tushare dependency

## Testing
- `python -m py_compile monitor_cn10y.py`
- `TUSHARE_TOKEN=FAKE python monitor_cn10y.py` *(fails: ModuleNotFoundError: No module named 'tushare')*
- `pip install tushare -q` *(fails: Could not find a version that satisfies the requirement tushare)*

------
https://chatgpt.com/codex/tasks/task_e_689ed555508883269c13af3235702a2e