### PR TITLE
Simplify CN10Y monitor workflow

### DIFF
--- a/.github/workflows/cn10y_monitor.yml
+++ b/.github/workflows/cn10y_monitor.yml
@@ -7,25 +7,15 @@ on:
     - cron: "10 0 * * 1-5"
 
 jobs:
-  run:
+  run-monitor:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-
-      - name: Install deps
-        run: |
-          pip install -r requirements.txt || pip install yfinance pandas requests
-
       - name: Run monitor
         env:
+          TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          THRESHOLD: "1.85"
-        run: |
-          python monitor_cn10y.py
+        run: python monitor_cn10y.py


### PR DESCRIPTION
## Summary
- streamline cn10y workflow to only checkout repository and run monitor script
- add TUSHARE_TOKEN to workflow environment variables

## Testing
- `python -m py_compile monitor_cn10y.py`


------
https://chatgpt.com/codex/tasks/task_e_689edc89c4d48326994d661edec8f2cf