### PR TITLE
Use Akshare for CN 10Y yield and drop Tushare

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Utility scripts for monitoring financial indicators and sending Telegram alerts.
 ## Scripts
 
 - `monitor_brent.py` – Brent crude oil price watcher.
-- `monitor_cn10y.py` – China 10-year government bond yield watcher. Uses the
-  Tushare Pro API and reads the token from the `TUSHARE_TOKEN` environment
-  variable.
+- `monitor_cn10y.py` – China 10-year government bond yield watcher. Fetches
+  data via [Akshare](https://akshare.akfamily.xyz/) and reads notification
+  credentials from the following environment variables:
+  - `TELEGRAM_BOT_TOKEN`
+  - `TELEGRAM_CHAT_ID`
+  - `THRESHOLD` (optional; default `1.85`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 yfinance>=0.2.43
 pandas>=2.2
 requests>=2.31
-tushare>=1.2.89
+akshare>=1.11.0


### PR DESCRIPTION
## Summary
- replace Tushare with Akshare for fetching China 10Y government bond yield
- remove TUSHARE_TOKEN dependency and document Telegram-related env vars
- update dependencies to include akshare and drop tushare

## Testing
- `python -m py_compile monitor_cn10y.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement akshare>=1.11.0)*
- `python monitor_cn10y.py` *(fails: ModuleNotFoundError: No module named 'akshare')*

------
https://chatgpt.com/codex/tasks/task_e_689f03ac14dc83268c8137ae68ffde85