### PR TITLE
Install dependencies for CN10Y monitor workflow

### DIFF
--- a/.github/workflows/cn10y_monitor.yml
+++ b/.github/workflows/cn10y_monitor.yml
@@ -13,6 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt || pip install pandas requests akshare
+
       - name: Run monitor
         env:
           TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}


### PR DESCRIPTION
## Summary
- Setup Python and install requirements before running the CN10Y monitor

## Testing
- `python monitor_cn10y.py` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a4155854c08326912d3f1527089d08